### PR TITLE
Revert adding type variables

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -65,7 +65,7 @@ atom-text-editor, :host {
 }
 
 .keyword {
-  color: @syntax-color-keyword;
+  color: @green;
 
   &.other {
     &.special-method {
@@ -83,7 +83,7 @@ atom-text-editor, :host {
 }
 
 .constant {
-  color: @syntax-color-constant;
+  color: @yellow;
 
   &.numeric,
   &.boolean,
@@ -118,7 +118,7 @@ atom-text-editor, :host {
 }
 
 .method .name {
-  color: @syntax-color-method;
+  color: @blue;
 }
 
 .operator.assignment {
@@ -130,7 +130,7 @@ atom-text-editor, :host {
 }
 
 .property-name {
-  color: @syntax-color-property;
+  color: @green;
 }
 
 .property-value {
@@ -161,9 +161,9 @@ atom-text-editor, :host {
 }
 
 .variable {
-  color: @syntax-color-variable;
+  color: @blue;
 
   &.constant {
-    color: @syntax-color-constant;
+    color: @yellow;
   }
 }


### PR DESCRIPTION
For the same reasons as in https://github.com/atom/solarized-dark-syntax/pull/39. This PR reverts this commit https://github.com/atom/solarized-light-syntax/commit/f16852d69a1dea22a6de56adfa162594292e5f73 except for the additions in `syntax-variables.less`.