### PR TITLE
Separate markup styles from gfm

### DIFF
--- a/index.less
+++ b/index.less
@@ -3,6 +3,7 @@
 
 @import 'base';
 @import 'markdown';
+@import "markup";
 @import 'ruby';
 @import 'terminal';
 @import 'git-diff';

--- a/styles/markdown.less
+++ b/styles/markdown.less
@@ -1,31 +1,13 @@
-atom-text-editor, :host {
-  .gfm {
-    .markup.italic {
-      font-style: italic;
-    }
+.gfm {
+  .link .entity {
+    color: @violet;
+  }
 
-    .markup.bold {
-      font-weight: bold;
-    }
+  .raw {
+    font-style: italic;
+  }
 
-    .markup.heading {
-      color: @orange;
-    }
-
-    .link {
-      color: @cyan;
-    }
-
-    .link .entity {
-      color: @violet;
-    }
-
-    .raw {
-      font-style: italic;
-    }
-
-    &.support {
-      color: @red;
-    }
+  &.support {
+    color: @red;
   }
 }

--- a/styles/markup.less
+++ b/styles/markup.less
@@ -1,0 +1,17 @@
+.markup {
+  &.italic {
+    font-style: italic;
+  }
+
+  &.bold {
+    font-weight: bold;
+  }
+
+  &.heading {
+    color: @orange;
+  }
+
+  &.link {
+    color: @cyan;
+  }
+}


### PR DESCRIPTION
This PR moves the `markup` styles into its own `markup.less` file. Then other markup languages get styled as well, not just `gfm`.

See https://github.com/atom/one-dark-syntax/pull/50