### PR TITLE
Fix missing keywords in ruby

### DIFF
--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -25,6 +25,9 @@
   .variable.constant {
     color: @yellow;
   }
+  .constant.boolean {
+    color: @cyan;
+  }
   .instance {
     .punctuation.definition {
       color: @blue;
@@ -83,8 +86,20 @@
   .variable.block {
     color: @blue;
   }
+  .variable.self {
+    color: @cyan;
+  }
   .punctuation.separator {
     color: @syntax-text-color;
+  }
+  .numeric {
+    color: @cyan;
+  }
+  .punctuation.section.regexp {
+    color: @red;
+  }
+  .string.interpolated {
+    color: @cyan;
   }
   .string.interpolated {
     .embedded.line.ruby {

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -56,6 +56,9 @@
   .keyword.control {
     color: @green;
   }
+  .keyword.operator {
+    color: @syntax-text-color;
+  }
   .special-method {
     color: @blue;
   }


### PR DESCRIPTION
Same as for Solarized dark: https://github.com/atom/solarized-dark-syntax/pull/61