### PR TITLE
Fix embedded JS closing script tags

### DIFF
--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -78,6 +78,9 @@
       }
     }
   }
+  &.embedded .entity.name.tag {
+    color: @blue;
+  }
 }
 .source.js.jsx {
   .entity.name.tag {


### PR DESCRIPTION
Same as https://github.com/atom/solarized-dark-syntax/pull/70. Fixes the highlighting of closing script tags when embedded in HTML.
