### PR TITLE
Highlight all strings

### DIFF
--- a/styles/languages/_base.less
+++ b/styles/languages/_base.less
@@ -9,9 +9,7 @@
 }
 
 .string {
-  &.quoted {
-    color: @cyan;
-  }
+  color: @cyan;
   &.regexp {
     color: @red;
   }


### PR DESCRIPTION
Not just quoted strings.

It's an issue in docstrings:

![screenshot](https://cloud.githubusercontent.com/assets/38760/18935034/54fc4550-85ab-11e6-89be-4cb96d720791.png)

Fixes https://github.com/atom/solarized-dark-syntax/issues/74