### PR TITLE
Color typescript types yellow

### DIFF
--- a/styles/syntax/typescript.less
+++ b/styles/syntax/typescript.less
@@ -5,8 +5,14 @@
     }
   }
 
-  .syntax--entity.syntax--name.syntax--type {
-    color: @yellow;
+  .syntax--entity {
+    &.syntax--name.syntax--type {
+      color: @yellow;
+    }
+
+    &.syntax--inherited-class {
+      color: @yellow;
+    }
   }
 
   .syntax--support.syntax--type {

--- a/styles/syntax/typescript.less
+++ b/styles/syntax/typescript.less
@@ -4,4 +4,12 @@
       color: @orange;
     }
   }
+
+  .syntax--entity.syntax--name.syntax--type {
+    color: @yellow;
+  }
+
+  .syntax--support.syntax--type {
+    color: @yellow;
+  }
 }


### PR DESCRIPTION
### Description of the Change

Coloring TypeScript types as solarized yellow.

In looking at how solarized normally styles "types", I noticed that the type coloring for TypeScript in atom was inconsistent.

Here's atom latest:
![solarized-light-ts-types-before](https://user-images.githubusercontent.com/238929/40551201-87d7acce-5ff9-11e8-8c8e-e51b696b0d9f.png)


You can see that primitive types get the green color while other types (whether interface or class) get a blue color. These really ought to be yellow.

Changes made in this pull request:
![solarized-light-ts-types-after](https://user-images.githubusercontent.com/238929/40551217-8d6413a8-5ff9-11e8-92cb-1f3b316f0d17.png)

 

### Alternate Designs

None.

### Benefits

Consistent type coloring for TypeScript.

### Possible Drawbacks

Some users might want primitive types and other types to be different.

### Applicable Issues

None.