### PR TITLE
Fix bracket matcher

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -52,4 +52,4 @@
 @syntax-comment-color: @base1;
 @syntax-subtle-color: @base00;
 @syntax-emphasized-color: @base01;
-@syntax-cursor-line: desaturate(darken(@syntax-background-color, 4%), 20%);
+@syntax-cursor-line: fade(darken(@syntax-background-color, 30%), 15%); // needs to be semi-transparent


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This makes the cursor-line semi-transparent so that the bracket matcher underneath can be seen.

![bracket-matcher](https://user-images.githubusercontent.com/378023/47895871-07b86180-deae-11e8-95dc-c44e336b345a.gif)

### Alternate Designs

We might could play with `z-index`, but that seems a bit more dangerous.

### Benefits

Bracket matcher is visible.

### Possible Drawbacks

- Cursor line has a bit different color now.
- Transparency can have negative performance impact.

### Applicable Issues

Fixes #44
